### PR TITLE
URL Cleanup

### DIFF
--- a/src/AspNetCoreExample/Program.cs
+++ b/src/AspNetCoreExample/Program.cs
@@ -27,7 +27,7 @@ namespace AspNetCoreExample
 
             if(!string.IsNullOrWhiteSpace(port))
             {
-                result.UseUrls($"http://+:{ port }");
+                result.UseUrls($"https://+:{ port }");
             }
             
             return result;

--- a/src/AspNetCoreExample/Properties/launchSettings.json
+++ b/src/AspNetCoreExample/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "ContractTests"
       },
-      "applicationUrl": "http://+:5000"
+      "applicationUrl": "https://+:5000"
     }
   }
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://json.schemastore.org/launchsettings.json (200) with 1 occurrences could not be migrated:  
   ([https](https://json.schemastore.org/launchsettings.json) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://+ (UnknownHostException) with 1 occurrences migrated to:  
  https://+ ([https](https://+) result UnknownHostException).
* [ ] http://+:5000 (UnknownHostException) with 1 occurrences migrated to:  
  https://+:5000 ([https](https://+:5000) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost/api-docs with 1 occurrences
* http://localhost/swagger with 1 occurrences
* http://localhost:60194 with 1 occurrences